### PR TITLE
U2F HID custom/mandatory command distinction error bugfix

### DIFF
--- a/firmware/inc/u2f_hid.h
+++ b/firmware/inc/u2f_hid.h
@@ -107,6 +107,14 @@ struct u2f_hid_init_response
 	uint8_t cflags;
 };
 
+struct CID
+{
+	uint32_t cid;
+	uint32_t last_used;
+	uint8_t busy;
+	uint8_t last_cmd;
+};
+
 typedef enum
 {
 	U2FHID_REPLY=0,
@@ -136,6 +144,8 @@ void u2f_hid_flush();
 // It will pass up to U2F protocol if necessary.
 //  @param req the U2F HID message
 void u2f_hid_request(struct u2f_hid_msg* req);
+
+struct CID* get_cid(uint32_t cid);
 
 // app_wink blink a light on the platform
 // must be implemented elsewhere for specific platform used

--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -158,11 +158,15 @@ int16_t main(void) {
 			case APP_NOTHING: {}break;                     // Idle state:
 
 			case APP_HID_MSG: {                            // HID msg received, pass to protocols:
-				uint8_t msg_is_hid_req;
+				struct CID* cid = NULL;
 
-				msg_is_hid_req = !custom_command(hid_msg); // Parse at first as a custom cmd: Custom cmd processing
-				if (msg_is_hid_req) {                      // It isnt a custom cmd, so must be a HID request
-					u2f_hid_request(hid_msg);              // HID msg processing
+				cid = get_cid(hid_msg->cid);
+				if (!cid->busy) {                          // There is no ongoing U2FHID transfer
+					if (!custom_command(hid_msg)) {
+						u2f_hid_request(hid_msg);
+					}
+				} else {
+					u2f_hid_request(hid_msg);
 				}
 
 				if (state == APP_HID_MSG) {                // The USB msg doesnt ask a special app state

--- a/firmware/src/u2f_hid.c
+++ b/firmware/src/u2f_hid.c
@@ -52,14 +52,6 @@ typedef enum
 	HID_READY,
 } HID_STATE;
 
-struct CID
-{
-	uint32_t cid;
-	uint32_t last_used;
-	uint8_t busy;
-	uint8_t last_cmd;
-};
-
 static struct hid_layer_param
 {
 	HID_STATE state;
@@ -233,7 +225,7 @@ static int8_t add_new_cid(uint32_t cid)
 	return -1;
 }
 
-static struct CID* get_cid(uint32_t cid)
+struct CID* get_cid(uint32_t cid)
 {
 	uint8_t i;
 	for(i = 0; i < CID_MAX; i++)


### PR DESCRIPTION
Continuation U2F HID packets with a sequence number equal to a custom command code are mistakenly processed as a custom command which leads to corrupted ping response and unwanted custom command execution.
The current bugfix corrects this issue, the firmware works well now with any size of ping commands.